### PR TITLE
Kapok support deserialization of boost::optional

### DIFF
--- a/kapok/DeSerializer.hpp
+++ b/kapok/DeSerializer.hpp
@@ -121,6 +121,17 @@ private:
 		ReadTuple(t.Meta(), val);
 	}
 
+	template <typename T>
+	auto ReadObject(T& t, Value& val) -> std::enable_if_t<is_optional<T>::value>
+	{
+		if (!val.IsNull())
+		{
+			std::remove_reference_t<decltype(*t)> tmp;
+			ReadObject(tmp, val);
+			t = tmp;
+		}
+	}
+
 	template<typename Tuple>
 	void ReadTuple(Tuple&& tp, Value& val)
 	{
@@ -243,10 +254,17 @@ private:
 		m_jsutil.ReadValue(std::forward<T>(t), v);
 	}
 
-	template<size_t N=0, typename T>
-	typename std::enable_if<is_user_class<T>::value>::type ReadValue(T&& t, Value& val)
+	//template<size_t N=0, typename T>
+	//typename std::enable_if<is_user_class<T>::value>::type ReadValue(T&& t, Value& val)
+	//{
+	//	//Value& p = val[t.first.c_str()];
+	//	ReadObject(t, val);
+	//}
+
+	template<size_t N = 0, typename T>
+	auto ReadValue(T&& t, Value& val) -> 
+		std::enable_if_t<is_optional<T>::value || is_user_class<T>::value>
 	{
-		//Value& p = val[t.first.c_str()];
 		ReadObject(t, val);
 	}
 

--- a/kapok/JsonUtil.hpp
+++ b/kapok/JsonUtil.hpp
@@ -204,6 +204,16 @@ public:
 		t = val.GetDouble();
 	}
 
+	void WriteValue(float val)
+	{
+		m_writer.Double(static_cast<double>(val));
+	}
+
+	void ReadValue(float& t, Value& val)
+	{
+		t = static_cast<float>(val.GetDouble());
+	}
+
 	template<typename T>
 	typename std::enable_if<std::is_same<T, bool>::value>::type WriteValue(T val)
 	{
@@ -216,6 +226,11 @@ public:
 	{
 		//不支持动态指针的原因是反序列化的时候涉及到指针的内存管理，反序列化不应该考虑为对象分配内存.
 		throw std::invalid_argument("not surpport dynamic pointer");
+	}
+
+	void WriteNull()
+	{
+		m_writer.Null();
 	}
 
 	void ReadValue(bool& t, Value& val)

--- a/kapok/Serializer.hpp
+++ b/kapok/Serializer.hpp
@@ -99,6 +99,10 @@ private:
 		{
 			WriteObject(*t);
 		}
+		else
+		{
+			m_jsutil.WriteNull();
+		}
 	}
 
 	//template<typename T>

--- a/main.cpp
+++ b/main.cpp
@@ -291,10 +291,33 @@ void test_optional()
 		META(a, b, str);
 	};
 
-	boost::optional<test_optional_struct> test = test_optional_struct{ 1, 1.0f, "hello optional!" };
+	// init without init test_optional_struct::str
+	boost::optional<test_optional_struct> to_sr = test_optional_struct{ 1, 1.0f };
 	Serializer sr;
-	sr.Serialize(test);
+	sr.Serialize(to_sr);
 	std::cout << sr.GetString() << std::endl;
+
+	DeSerializer ds;
+	ds.Parse(sr.GetString());
+	boost::optional<test_optional_struct> to_ds;
+	ds.Deserialize(to_ds);
+	bool test_pass =
+		to_ds->a == to_sr->a &&
+		to_ds->b == to_sr->b &&
+		to_ds->str == to_sr->str;
+
+	//full init
+	to_sr = test_optional_struct{ 3, 2.0f, "hello optional" };
+	sr.Serialize(to_sr);
+	std::cout << sr.GetString() << std::endl;
+
+	ds.Parse(sr.GetString());
+	to_ds.reset();
+	ds.Deserialize(to_ds);
+	test_pass =
+		to_ds->a == to_sr->a &&
+		to_ds->b == to_sr->b &&
+		to_ds->str == to_sr->str;
 }
 
 TEST_CASE(example)


### PR DESCRIPTION
1.  Compatible with float type
2. Serialize an empty boost::optional object as Null in json
3. Support deserialization of boost::optional
4. update tests 
